### PR TITLE
Fail safe copy.

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -30,15 +30,18 @@ function xmldb_datafield_email_install() {
     $target = implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'pix', 'email.svg']);
     $link = implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', '..', 'pix', 'field', 'email.svg']);
 
-    echo 'Create symlink for email icon... ';
-    if (!symlink($target, $link)) {
-        echo 'failed' . PHP_EOL . 'Copy email icon... ';
-        if (!\copy($target, $link)) {
-            echo 'failed' . PHP_EOL . "Please copy {$target} to {$link}" . PHP_EOL;
+
+    if (!file_exists($target)) {
+        echo 'Create symlink for email icon... ';
+        if (!symlink($target, $link)) {
+            echo 'failed' . PHP_EOL . 'Copy email icon... ';
+            if (!\copy($target, $link)) {
+                echo 'failed' . PHP_EOL . "Please copy {$target} to {$link}" . PHP_EOL;
+            } else {
+                echo 'ok' . PHP_EOL;
+            }
         } else {
             echo 'ok' . PHP_EOL;
         }
-    } else {
-        echo 'ok' . PHP_EOL;
     }
 }


### PR DESCRIPTION
Otherwise, if (!symlink($target, $link)) could throw a warning and install scripts must not produce warnings.